### PR TITLE
[Fleet Management] Cost tab fixes

### DIFF
--- a/projects/fleet-management-grid/src/app/fleet-management-grid/fleet-management-grid.component.html
+++ b/projects/fleet-management-grid/src/app/fleet-management-grid/fleet-management-grid.component.html
@@ -114,7 +114,8 @@
             <div class="chart-container pie-chart-container">
               <div class="chart-header">
                 <span class="chart-title">Costs per Type</span>
-                <igx-select #select class="chart-select" [value]="periods.costPerTypePeriod" (selectionChanging)="onPeriodChange($event, 'costsPerType')">
+                <igx-select #select class="chart-select" [value]="periods[dataItem.vehicleId]?.costPerTypePeriod || Period.YTD"
+                (selectionChanging)="onPeriodChange($event, 'costsPerType', dataItem.vehicleId)">
                   <label igxLabel>Period</label>
                   <igx-select-item [value]="Period.YTD">YTD</igx-select-item>
                   <igx-select-item [value]="Period.ThreeMonths">Last 3 Months</igx-select-item>
@@ -132,7 +133,7 @@
                   valueMemberPath="value"
                   labelsPosition="OutsideEnd"
                   radiusFactor="0.7"
-                  [dataSource]="dataService.getCostsPerTypeData(dataItem.vehicleId, periods.costPerTypePeriod)"
+                  [dataSource]="dataService.getCostsPerTypeData(dataItem.vehicleId, periods[dataItem.vehicleId]?.costPerTypePeriod || Period.YTD)"
                   actualLabelOuterColor="#ededed"
                   >
                 </igx-pie-chart>
@@ -142,7 +143,8 @@
             <div class="chart-container area-chart-container">
               <div class="chart-header">
                 <span class="chart-title">Costs per Meter, per Quarter</span>
-                <igx-select #select class="chart-select" [value]="periods.costPerMeterPeriod" (selectionChanging)="onPeriodChange($event, 'costsPerMeter')">
+                <igx-select #select class="chart-select" [value]="periods[dataItem.vehicleId]?.costPerMeterPeriod || Period.YTD"
+                (selectionChanging)="onPeriodChange($event, 'costsPerMeter', dataItem.vehicleId)">
                   <label igxLabel>Period</label>
                   <igx-select-item value="ytd">YTD</igx-select-item>
                   <igx-select-item value="'2023'">2023</igx-select-item>
@@ -155,7 +157,7 @@
                 <igx-category-chart
                   name="chart"
                   class="chart-canvas"
-                  [dataSource]="dataService.getCostsPerMeterData(dataItem.vehicleId, periods.costPerMeterPeriod)"
+                  [dataSource]="dataService.getCostsPerMeterData(dataItem.vehicleId, periods[dataItem.vehicleId]?.costPerMeterPeriod || Period.YTD)"
                   chartType="Area"
                   isHorizontalZoomEnabled="false"
                   isVerticalZoomEnabled="false"
@@ -174,7 +176,8 @@
             <div class="chart-container column-chart-container">
               <div class="chart-header">
                 <span class="chart-title">Fuel Costs per Month</span>
-                <igx-select #select class="chart-select" [value]="periods.fuelCostPeriod" (selectionChanging)="onPeriodChange($event, 'fuelCosts')">
+                <igx-select #select class="chart-select" [value]="periods[dataItem.vehicleId]?.fuelCostPeriod || Period.YTD"
+                (selectionChanging)="onPeriodChange($event, 'fuelCosts', dataItem.vehicleId)">
                   <label igxLabel>Period</label>
                   <igx-select-item [value]="Period.YTD">YTD</igx-select-item>
                   <igx-select-item [value]="Period.ThreeMonths">Last 3 Months</igx-select-item>
@@ -188,7 +191,7 @@
                   class="column-chart"
                   #chart
                   chartType="Column"
-                  [dataSource]="dataService.getFuelCostsData(dataItem.vehicleId, periods.fuelCostPeriod)"
+                  [dataSource]="dataService.getFuelCostsData(dataItem.vehicleId, periods[dataItem.vehicleId]?.fuelCostPeriod || Period.YTD)"
                   yAxisTitle="Costs in USD"
                   isHorizontalZoomEnabled="false"
                   isVerticalZoomEnabled="false"

--- a/projects/fleet-management-grid/src/app/fleet-management-grid/fleet-management-grid.component.scss
+++ b/projects/fleet-management-grid/src/app/fleet-management-grid/fleet-management-grid.component.scss
@@ -6,7 +6,6 @@
 
 :root {
   --primary-text-color: #f5f5f5;
-  --default-border: 1px solid #8A8A8A;
 }
 
 :host {
@@ -94,7 +93,7 @@ igx-card {
   height: 100%;
   padding: 15px;
   border-radius: 6px;
-  border: var(--default-border);
+  border: 1px solid #8A8A8A;
 }
 
 .content-wrapper {

--- a/projects/fleet-management-grid/src/app/fleet-management-grid/fleet-management-grid.component.ts
+++ b/projects/fleet-management-grid/src/app/fleet-management-grid/fleet-management-grid.component.ts
@@ -88,11 +88,12 @@ export class FleetManagementGridComponent implements OnInit {
 
   //chart periods
   protected Period = Period;
-  protected periods = {
+  /* protected periods = {
     costPerTypePeriod: Period.YTD,
     costPerMeterPeriod: Period.YTD,
     fuelCostPeriod: Period.YTD
-  }
+  } */
+  protected periods: { [vehicleId: string]: { costPerTypePeriod: Period, costPerMeterPeriod: Period, fuelCostPeriod: Period } } = {};
 
   //driver details for detail overlay
   protected driverDetails: DriverDetails = {
@@ -140,13 +141,21 @@ export class FleetManagementGridComponent implements OnInit {
   }
 
   //handling for chart periods
-  protected onPeriodChange(event: any, chart: string): void {
+  protected onPeriodChange(event: any, chart: string, vehicleId: string): void {
+    if (!this.periods[vehicleId]) {
+      this.periods[vehicleId] = {
+        costPerTypePeriod: Period.YTD,
+        costPerMeterPeriod: Period.YTD,
+        fuelCostPeriod: Period.YTD
+      };
+    }
+
     if (chart === ChartType.CostPerType) {
-      this.periods.costPerTypePeriod = event.newSelection.value;
+      this.periods[vehicleId].costPerTypePeriod = event.newSelection.value;
     } else if (chart === ChartType.CostPerMeter) {
-      this.periods.costPerMeterPeriod = event.newSelection.value;
+      this.periods[vehicleId].costPerMeterPeriod = event.newSelection.value;
     } else if (chart === ChartType.FuelCosts) {
-      this.periods.fuelCostPeriod = event.newSelection.value;
+      this.periods[vehicleId].fuelCostPeriod = event.newSelection.value;
     }
 
   }

--- a/projects/fleet-management-grid/src/assets/data/cost.json
+++ b/projects/fleet-management-grid/src/assets/data/cost.json
@@ -84,6 +84,10 @@
         {
           "quarter": "Q3",
           "costPerMeter": 55
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 61
         }
       ],
       "'2023'": [
@@ -280,6 +284,10 @@
         {
           "quarter": "Q3",
           "costPerMeter": 55
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 64
         }
       ],
       "'2023'": [
@@ -491,9 +499,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 60
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 68
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -511,7 +523,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -529,7 +541,7 @@
           "costPerMeter": 54
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -547,7 +559,7 @@
           "costPerMeter": 48
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -702,9 +714,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 52
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 50
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -722,7 +738,7 @@
           "costPerMeter": 56
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -740,7 +756,7 @@
           "costPerMeter": 51
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 13
@@ -758,7 +774,7 @@
           "costPerMeter": 45
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 9
@@ -914,9 +930,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 53
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 49
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 15
@@ -934,7 +954,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 19
@@ -952,7 +972,7 @@
           "costPerMeter": 52
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -970,7 +990,7 @@
           "costPerMeter": 48
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 11
@@ -1125,9 +1145,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 60
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 45
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 18
@@ -1145,7 +1169,7 @@
           "costPerMeter": 62
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -1163,7 +1187,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -1181,7 +1205,7 @@
           "costPerMeter": 45
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -1336,9 +1360,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 57
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 68
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -1356,7 +1384,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -1374,7 +1402,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 11
@@ -1392,7 +1420,7 @@
           "costPerMeter": 48
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 9
@@ -1547,9 +1575,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 57
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 53
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -1567,7 +1599,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -1585,7 +1617,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 11
@@ -1603,7 +1635,7 @@
           "costPerMeter": 48
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 9
@@ -1758,9 +1790,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 50
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 65
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -1778,7 +1814,7 @@
           "costPerMeter": 60
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 18
@@ -1796,7 +1832,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -1814,7 +1850,7 @@
           "costPerMeter": 49
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -1969,9 +2005,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 50
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 47
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -1989,7 +2029,7 @@
           "costPerMeter": 60
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 18
@@ -2007,7 +2047,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -2025,7 +2065,7 @@
           "costPerMeter": 49
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -2180,9 +2220,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 50
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 63
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -2200,7 +2244,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -2218,7 +2262,7 @@
           "costPerMeter": 54
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -2236,7 +2280,7 @@
           "costPerMeter": 45
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 9
@@ -2391,9 +2435,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 50
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 55
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -2411,7 +2459,7 @@
           "costPerMeter": 55
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 18
@@ -2429,7 +2477,7 @@
           "costPerMeter": 51
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -2447,7 +2495,7 @@
           "costPerMeter": 46
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -2602,6 +2650,10 @@
         {
           "quarter": "Q3",
           "costPerMeter": 55
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 68
         }
       ],
       "'2023'": [
@@ -2798,6 +2850,10 @@
         {
           "quarter": "Q3",
           "costPerMeter": 55
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 66
         }
       ],
       "'2023'": [
@@ -3009,9 +3065,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 60
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 47
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -3029,7 +3089,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -3047,7 +3107,7 @@
           "costPerMeter": 54
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -3065,7 +3125,7 @@
           "costPerMeter": 48
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -3220,9 +3280,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 52
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 68
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -3240,7 +3304,7 @@
           "costPerMeter": 56
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -3258,7 +3322,7 @@
           "costPerMeter": 51
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 13
@@ -3276,7 +3340,7 @@
           "costPerMeter": 45
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 9
@@ -3432,9 +3496,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 53
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 64
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 15
@@ -3452,7 +3520,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 19
@@ -3470,7 +3538,7 @@
           "costPerMeter": 52
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -3488,7 +3556,7 @@
           "costPerMeter": 48
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 11
@@ -3643,9 +3711,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 60
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 55
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 18
@@ -3663,7 +3735,7 @@
           "costPerMeter": 62
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -3681,7 +3753,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -3699,7 +3771,7 @@
           "costPerMeter": 45
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -3854,9 +3926,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 57
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 46
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -3874,7 +3950,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -3892,7 +3968,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 11
@@ -3910,7 +3986,7 @@
           "costPerMeter": 48
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 9
@@ -4065,9 +4141,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 57
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 68
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -4085,7 +4165,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 16
@@ -4103,7 +4183,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 11
@@ -4121,7 +4201,7 @@
           "costPerMeter": 48
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 9
@@ -4276,9 +4356,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 50
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 57
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -4296,7 +4380,7 @@
           "costPerMeter": 60
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 18
@@ -4314,7 +4398,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -4332,7 +4416,7 @@
           "costPerMeter": 49
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -4487,9 +4571,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 50
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 53
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -4507,7 +4595,7 @@
           "costPerMeter": 60
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 18
@@ -4525,7 +4613,7 @@
           "costPerMeter": 53
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -4543,7 +4631,7 @@
           "costPerMeter": 49
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -4698,9 +4786,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 50
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 47
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -4718,7 +4810,7 @@
           "costPerMeter": 58
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -4736,7 +4828,7 @@
           "costPerMeter": 54
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -4754,7 +4846,7 @@
           "costPerMeter": 45
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 9
@@ -4909,9 +5001,13 @@
         {
           "quarter": "Q3",
           "costPerMeter": 50
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 55
         }
       ],
-      "2023": [
+      "'2023'": [
         {
           "quarter": "Q1",
           "costPerMeter": 14
@@ -4929,7 +5025,7 @@
           "costPerMeter": 55
         }
       ],
-      "2022": [
+      "'2022'": [
         {
           "quarter": "Q1",
           "costPerMeter": 18
@@ -4947,7 +5043,7 @@
           "costPerMeter": 51
         }
       ],
-      "2021": [
+      "'2021'": [
         {
           "quarter": "Q1",
           "costPerMeter": 12
@@ -4965,7 +5061,7 @@
           "costPerMeter": 46
         }
       ],
-      "2020": [
+      "'2020'": [
         {
           "quarter": "Q1",
           "costPerMeter": 10
@@ -5120,6 +5216,10 @@
         {
           "quarter": "Q3",
           "costPerMeter": 55
+        },
+        {
+          "quarter": "Q4",
+          "costPerMeter": 62
         }
       ],
       "'2023'": [


### PR DESCRIPTION
What this PR fixes:
- fix missing chart container borders
- Cost Per Meter Per Quarter chart data was not loading for some periods on some entries. Now should be okay
- added Q4 data for the YTD period for Cost Per Meter Per Quarter charts
- periods were tracked globally so when you select a period for a specific chart, it would update the selected period on this chart for all entries. Now periods are tracked per entry