### PR TITLE
Fixed formatting of some fields + collapsible address formatting

### DIFF
--- a/projects/erp-hgrid/src/app/erp-hgrid-sample/erp-hgrid-sample.component.html
+++ b/projects/erp-hgrid/src/app/erp-hgrid-sample/erp-hgrid-sample.component.html
@@ -130,7 +130,7 @@
                 <igx-column
                     field="delivery.dateOrdered"
                     header="Date Ordered"
-                    dataType="string"
+                    dataType="date"
                     width="12%"
                     [sortable]="true"
                     [resizable]="true"
@@ -142,7 +142,7 @@
                 <igx-column
                     field="delivery.dateOrdered"
                     header="Date Ordered"
-                    dataType="string"
+                    dataType="date"
                     width="12%"
                     [sortable]="true"
                     [resizable]="true"
@@ -152,7 +152,7 @@
                 <igx-column
                     field="delivery.dateShipped"
                     header="Date Shipped"
-                    dataType="string"
+                    dataType="date"
                     width="12%"
                     [sortable]="true"
                     [resizable]="true"
@@ -162,7 +162,7 @@
                 <igx-column
                     field="delivery.dateDelivered"
                     header="Date Delivered"
-                    dataType="string"
+                    dataType="date"
                     width="12%"
                     [sortable]="true"
                     [resizable]="true"
@@ -215,11 +215,12 @@
                 <igx-column
                     field="orderInformation.zipCode"
                     header="Zip Code"
-                    dataType="string"
+                    dataType="number"
                     width="9%"
                     [sortable]="true"
                     [resizable]="true"
-                    [visibleWhenCollapsed]="false">
+                    [visibleWhenCollapsed]="false"
+                    [formatter]="formatNumberAsIs">
                 </igx-column>
                 <igx-column
                     field="orderInformation"
@@ -228,7 +229,8 @@
                     [sortable]="true"
                     [resizable]="true"
                     [visibleWhenCollapsed]="false"
-                    [formatter]="formatAddress">
+                    [formatter]="formatAddress"
+                    [filters]="shortAddressFilteringOperand">
                 </igx-column>
 
                 <!-- Show this column when collapsed -->
@@ -239,7 +241,8 @@
                     [sortable]="true"
                     [resizable]="true"
                     [visibleWhenCollapsed]="true"
-                    [formatter]="formatAddress">
+                    [formatter]="formatFullAddress"
+                    [filters]="fullAddressFilteringOperand">
                 </igx-column>
 
             </igx-column-group>

--- a/projects/erp-hgrid/src/app/erp-hgrid-sample/erp-hgrid-sample.component.ts
+++ b/projects/erp-hgrid/src/app/erp-hgrid-sample/erp-hgrid-sample.component.ts
@@ -37,7 +37,8 @@ import {
   VerticalAlignment,
   THEME_TOKEN,
   ThemeToken,
-  IgxGridToolbarDirective
+  IgxGridToolbarDirective,
+  IgxStringFilteringOperand
 } from 'igniteui-angular';
 import { IgxSparklineModule } from 'igniteui-angular-charts';
 import { defineComponents, IgcRatingComponent } from 'igniteui-webcomponents';
@@ -99,6 +100,8 @@ export class ErpHGridSampleComponent implements AfterViewInit {
   public rowisland!: IgxRowIslandComponent;
   @ViewChild('imageElement', { static: true }) imageElement!: ElementRef;
   @ViewChild('imageDialog', { static: true }) imageDialog!: IgxDialogComponent;
+  public fullAddressFilteringOperand = FullAddressFilteringOperand.instance();
+  public shortAddressFilteringOperand = new FullAddressFilteringOperand(true);
 
   public hgridData: TemplateDataModel[];
   public selectionMode: GridSelectionMode = 'multiple';
@@ -110,7 +113,6 @@ export class ErpHGridSampleComponent implements AfterViewInit {
   ) {
     // data
     this.hgridData = this.erpDataService.getProducts();
-    const x = this.erpDataService.getProductsJson();
 
     // Icons used
     this.iconService.addSvgIconFromText(dropbox.name, dropbox.value, 'imx-icons');
@@ -145,7 +147,11 @@ export class ErpHGridSampleComponent implements AfterViewInit {
   }
 
   public formatAddress(value: OrderDetails): string {
-    return `${value.streetName} ${value.streetNumber}`;
+    return `${value.streetNumber} ${value.streetName}`;
+  }
+
+  public formatFullAddress(value: OrderDetails): string {
+    return `${value.streetNumber} ${value.streetName}, ${value.zipCode} ${value.city}, ${value.country}`;
   }
 
   public formatNumberAsIs(value: number): number {
@@ -182,5 +188,104 @@ export class ErpHGridSampleComponent implements AfterViewInit {
     if(dialog) {
       dialog.close();
     }
+  }
+}
+
+export class FullAddressFilteringOperand extends IgxStringFilteringOperand {
+  public constructor(isAddressShort: boolean = false) {
+    super();
+    const getShortAddress = (target: any) => `${target.streetNumber} ${target.streetName}`;
+    const getFullAddress = (target: any) => `${target.streetNumber} ${target.streetName}, ${target.zipCode} ${target.city}, ${target.country}`;
+
+    // Rewriting filtering operations to work on the address field
+    // as it is an object with properties
+    // and we can't filter it like a normal string field
+    const customOperations = [
+      {
+        iconName: 'filter_contains',
+        isUnary: false,
+        logic: (target: any, searchVal: string, ignoreCase?: boolean) => {
+          const address = isAddressShort ? getShortAddress(target) : getFullAddress(target);
+          ignoreCase = true;
+          const search = IgxStringFilteringOperand.applyIgnoreCase(searchVal, ignoreCase);
+          target = IgxStringFilteringOperand.applyIgnoreCase(address, ignoreCase);
+          return target.indexOf(search) !== -1;
+        },
+        name: 'Contains'
+      },
+      {
+        iconName: 'filter_does_not_contain',
+        isUnary: false,
+        logic: (target: any, searchVal: string, ignoreCase?: boolean) => {
+          const address = isAddressShort ? getShortAddress(target) : getFullAddress(target);
+          ignoreCase = true;
+          const search = IgxStringFilteringOperand.applyIgnoreCase(searchVal, ignoreCase);
+          target = IgxStringFilteringOperand.applyIgnoreCase(address, ignoreCase);
+          return target.indexOf(search) === -1;
+        },
+        name: 'Does Not Contain'
+      },
+      {
+        iconName: 'filter_starts_with',
+        isUnary: false,
+        logic: (target: any, searchVal: string, ignoreCase?: boolean) => {
+          const address = isAddressShort ? getShortAddress(target) : getFullAddress(target);
+          ignoreCase = true;
+          const search = IgxStringFilteringOperand.applyIgnoreCase(searchVal, ignoreCase);
+          target = IgxStringFilteringOperand.applyIgnoreCase(address, ignoreCase);
+          return target.startsWith(search);
+        },
+        name: 'Starts With'
+      },
+      {
+        iconName: 'filter_ends_with',
+        isUnary: false,
+        logic: (target: any, searchVal: string, ignoreCase?: boolean) => {
+          const address = isAddressShort ? getShortAddress(target) : getFullAddress(target);
+          ignoreCase = true;
+          const search = IgxStringFilteringOperand.applyIgnoreCase(searchVal, ignoreCase);
+          target = IgxStringFilteringOperand.applyIgnoreCase(address, ignoreCase);
+          return target.endsWith(search);
+        },
+        name: 'Ends With'
+      },
+      {
+        iconName: 'filter_equal',
+        isUnary: false,
+        logic: (target: any, searchVal: string, ignoreCase?: boolean) => {
+          const address = isAddressShort ? getShortAddress(target) : getFullAddress(target);
+          ignoreCase = true;
+          const search = IgxStringFilteringOperand.applyIgnoreCase(searchVal, ignoreCase);
+          target = IgxStringFilteringOperand.applyIgnoreCase(address, ignoreCase);
+          return target === search;
+        },
+        name: 'Equals'
+      },
+      {
+        iconName: 'filter_not_equal',
+        isUnary: false,
+        logic: (target: any, searchVal: string, ignoreCase?: boolean) => {
+          const address = isAddressShort ? getShortAddress(target) : getFullAddress(target);
+          ignoreCase = true;
+          const search = IgxStringFilteringOperand.applyIgnoreCase(searchVal, ignoreCase);
+          target = IgxStringFilteringOperand.applyIgnoreCase(address, ignoreCase);
+          return target !== search;
+        },
+        name: 'Does Not Equal'
+      },
+    ];
+
+    const emptyOperators = [
+        // 'Empty'
+        this.operations[6],
+        // 'Not Empty'
+        this.operations[7],
+        // 'Null'
+        this.operations[8],
+        // 'Not Null'
+        this.operations[9],
+    ];
+
+    this.operations = customOperations.concat(emptyOperators);
   }
 }


### PR DESCRIPTION
Resolves #65 

Fixed filtering on
- Date columns: we were using the string filtering until now
- Zip Code: changed to filtering it as a number instead of string
- Address: Filtering was not working at all because we are using an object for a field. Added custom filtering logic for both short  and long (when Order Information is collapsed) address.