### PR TITLE
Separate grids in build pipeline angular-grid-demos

### DIFF
--- a/azure-pipelines/igniteui-angular-grid-examples.yml
+++ b/azure-pipelines/igniteui-angular-grid-examples.yml
@@ -77,7 +77,7 @@ stages:
               fi
             }
 
-            # Pass 1: All first-level directories in projects/grids
+            # Pass 1: All first-level directories in projects/grids/
             create_zips "$(Build.SourcesDirectory)/projects/grids"
 
             # Pass 2: All first-level directories in projects/charts/

--- a/azure-pipelines/igniteui-angular-grid-examples.yml
+++ b/azure-pipelines/igniteui-angular-grid-examples.yml
@@ -77,8 +77,8 @@ stages:
               fi
             }
 
-            # Pass 1: All first-level directories in projects/
-            create_zips "$(Build.SourcesDirectory)/projects"
+            # Pass 1: All first-level directories in projects/grids
+            create_zips "$(Build.SourcesDirectory)/projects/grids"
 
             # Pass 2: All first-level directories in projects/charts/
             create_zips "$(Build.SourcesDirectory)/projects/charts"

--- a/azure-pipelines/igniteui-angular-grid-examples.yml
+++ b/azure-pipelines/igniteui-angular-grid-examples.yml
@@ -105,7 +105,6 @@ stages:
           workingDir: '$(Build.SourcesDirectory)'
           customCommand: 'install -g @angular/cli'
 
-
       - task: Npm@1
         displayName: 'Register licensed npm registry in .npmrc'
         inputs:


### PR DESCRIPTION
This PR separates grids the same way like charts in a different folder in /projects