### PR TITLE
Add caching rules for immutable files in web.config

### DIFF
--- a/web.config
+++ b/web.config
@@ -2,6 +2,24 @@
 <configuration>
 
 <system.webServer>
+    <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
+        <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" />
+        <dynamicTypes>
+            <add enabled="true" mimeType="text/*"/>
+            <add enabled="true" mimeType="message/*"/>
+            <add enabled="true" mimeType="application/javascript"/>
+            <add enabled="true" mimeType="application/json"/>
+            <add enabled="false" mimeType="*/*"/>
+        </dynamicTypes>
+        <staticTypes>
+            <add enabled="true" mimeType="text/*"/>
+            <add enabled="true" mimeType="message/*"/>
+            <add enabled="true" mimeType="application/javascript"/>
+            <add enabled="true" mimeType="application/json"/>
+            <add enabled="true" mimeType="image/svg+xml"/>
+            <add enabled="false" mimeType="*/*"/>
+        </staticTypes>
+    </httpCompression>
   <rewrite>
     <rules>
       <rule name="Angular Routes" stopProcessing="true">
@@ -13,7 +31,52 @@
         <action type="Rewrite" url="./index.html" />
       </rule>
     </rules>
+    <outboundRules>
+      <rule name="Cache immutable files" preCondition="IsImmutable">
+        <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />
+        <action type="Rewrite" value="public, max-age=31536000, immutable" />
+      </rule>
+      <preConditions>
+        <preCondition name="IsImmutable" logicalGrouping="MatchAny">
+          <add input="{REQUEST_URI}" pattern="styles-.*\.css$" />
+          <add input="{REQUEST_URI}" pattern="chunk-.*\.js$" />
+          <add input="{REQUEST_URI}" pattern="main-.*\.js$" />
+          <add input="{REQUEST_URI}" pattern="polyfills-.*\.js$" />
+          <add input="{REQUEST_URI}" pattern="/media/.*" />
+        </preCondition>
+      </preConditions>
+    </outboundRules>
   </rewrite>
 </system.webServer>
+  <staticContent>
+    <!-- 1 hour public cache for regular static assets -->
+    <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.01:00:00" cacheControlCustom="public" />
 
+    <remove fileExtension=".json" />
+    <remove fileExtension=".csv" />
+    <remove fileExtension=".shp" />
+    <remove fileExtension=".dbf" />
+    <remove fileExtension=".itf" />
+    <remove fileExtension=".svg" />
+
+    <mimeMap fileExtension=".json" mimeType="application/json;charset=UTF-8;" />
+    <mimeMap fileExtension=".csv"  mimeType="application/csv;charset=UTF-8;" />
+    <mimeMap fileExtension=".shp"  mimeType="application/octet-stream" />
+    <mimeMap fileExtension=".dbf"  mimeType="application/octet-stream" />
+    <mimeMap fileExtension=".itf"  mimeType="application/octet-stream" />
+    <mimeMap fileExtension=".svg"  mimeType="image/svg+xml" />
+  </staticContent>
+  <httpProtocol>
+      <customHeaders>
+          <add name="X-XSS-Protection" value="0" />
+      </customHeaders>
+  </httpProtocol>
+<location path="index.html">
+  <system.webServer>
+    <staticContent>
+      <!-- Short-lived cache for index.html -->
+      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.00:05:00" cacheControlCustom="public" />
+    </staticContent>
+  </system.webServer>
+</location>
 </configuration>

--- a/web.config
+++ b/web.config
@@ -47,7 +47,6 @@
       </preConditions>
     </outboundRules>
   </rewrite>
-</system.webServer>
   <staticContent>
     <!-- 1 hour public cache for regular static assets -->
     <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.01:00:00" cacheControlCustom="public" />
@@ -71,12 +70,13 @@
           <add name="X-XSS-Protection" value="0" />
       </customHeaders>
   </httpProtocol>
-<location path="index.html">
-  <system.webServer>
-    <staticContent>
-      <!-- Short-lived cache for index.html -->
-      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.00:05:00" cacheControlCustom="public" />
-    </staticContent>
   </system.webServer>
-</location>
+	<location path="index.html">
+	  <system.webServer>
+	    <staticContent>
+	      <!-- Short-lived cache for index.html -->
+	      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="0.00:05:00" cacheControlCustom="public" />
+	    </staticContent>
+	  </system.webServer>
+	</location>
 </configuration>


### PR DESCRIPTION
Added outbound rules for caching immutable files and defined preconditions for specific file patterns.
Based on the changes that Pablo introduced in https://github.com/IgniteUI/igniteui-angular-samples/pull/3879 for the other Angular samples

**Why**:
SPA had a 1 year cache for all static files, including the index.html
This is terribly bad for updating the app because you get an older version of the app unless you force reload.
This can also lead to crashes, because the cached index.html will reference related scripts that are no longer there.

**How:**
 - New rules:
   * index.html  5 min public cache
   * Hashed files 1 year immutable public cache
     * `main-<hash>.js`
     * `chunk-<hash>.js`
     * `polyfills-<hash>.js`
     * `styles-<hash>.css`
  * Other static assets 1 hour

Additionally:
 - Enable SVG compression

These changes are already applied to 
 - angular-demos/
 - angular-demos-grid-crm/
 - angular-demos-lob/
 via the afore-mentioned PR https://github.com/IgniteUI/igniteui-angular-samples/pull/3879 

After testing this, the same approach should be applied to angular-grid-examples as well